### PR TITLE
[WIP] Structural equality tests.

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -115,7 +115,7 @@ Alternative install with conda (for developing)
 # Install the xnd package into a local directory.
 
 # Create and activate a new conda environment:
-conda create --name xnd python=3.7
+conda create --name xnd python=3.7 make conda-build
 conda activate xnd
 
 # Use conda to install ndtypes (if you also want to work on ndtypes, please

--- a/libxnd/Makefile.in
+++ b/libxnd/Makefile.in
@@ -35,9 +35,9 @@ GM_CUDA_CXXFLAGS = $(strip $(CONFIGURE_CUDA_CXXFLAGS) $(CUDA_CXXFLAGS))
 default: $(LIBSTATIC) $(LIBSHARED)
 
 
-OBJS = bitmaps.o bounds.o copy.o equal.o shape.o split.o xnd.o
+OBJS = bitmaps.o bounds.o copy.o equal.o identical.o shape.o split.o xnd.o
 
-SHARED_OBJS = .objs/bitmaps.o .objs/bounds.o .objs/copy.o .objs/equal.o .objs/shape.o .objs/split.o .objs/xnd.o
+SHARED_OBJS = .objs/bitmaps.o .objs/bounds.o .objs/copy.o .objs/equal.o .objs/identical.o .objs/shape.o .objs/split.o .objs/xnd.o
 
 ifdef CUDA_CXX
 OBJS += cuda_memory.o
@@ -86,6 +86,14 @@ Makefile equal.c xnd.h
 .objs/equal.o:\
 Makefile equal.c xnd.h
 	$(CC) $(XND_CFLAGS_SHARED) -c equal.c -o .objs/equal.o
+
+identical.o:\
+Makefile identical.c xnd.h
+	$(CC) $(XND_CFLAGS) -c identical.c
+
+.objs/identical.o:\
+Makefile identical.c xnd.h
+	$(CC) $(XND_CFLAGS_SHARED) -c identical.c -o .objs/identical.o
 
 shape.o:\
 Makefile shape.c overflow.h xnd.h

--- a/libxnd/bitmaps.c
+++ b/libxnd/bitmaps.c
@@ -231,6 +231,115 @@ bitmap_init(xnd_bitmap_t *b, const ndt_t *t, int64_t nitems, ndt_context_t *ctx)
     }
 }
 
+/*****************************************************************************/
+/*                      Structural identity                                  */
+/*****************************************************************************/
+
+static int
+bitmap_identical(const xnd_bitmap_t *xb, const xnd_bitmap_t *yb,
+                 const ndt_t *t, int64_t nitems,
+                 ndt_context_t *ctx) {
+
+  int64_t shape, i, k;
+  int64_t n;
+
+  assert(ndt_is_concrete(t));
+
+  if (ndt_is_optional(t) && memcmp(xb->data, yb->data, (nitems + 7) / 8)) {
+    return 0;
+  }
+
+  if (!ndt_subtree_is_optional(t)) {
+    return 1;
+  }
+
+  switch (t->tag) {
+  case FixedDim: {
+    shape = t->FixedDim.shape;
+    return bitmap_identical(xb, yb, t->FixedDim.type, nitems * shape, ctx);
+  }
+
+  case VarDim: {
+    assert(nitems == 1);
+    n = nitems;
+    if (t->ndim == 1) {
+      int32_t noffsets = t->Concrete.VarDim.offsets->n;
+      n = t->Concrete.VarDim.offsets->v[noffsets - 1];
+    }
+    return bitmap_identical(xb, yb, t->VarDim.type, n, ctx);
+  }
+
+  case Tuple: {
+    shape = t->Tuple.shape;
+
+    for (i = 0; i < nitems; i++) {
+      for (k = 0; k < shape; k++) {
+        if (!bitmap_identical(xb->next + i * shape + k,
+                              yb->next + i * shape + k, t->Tuple.types[k], 1,
+                              ctx))
+          return 0;
+      }
+    }
+
+    return 1;
+  }
+
+  case Record: {
+    shape = t->Record.shape;
+
+    for (i = 0; i < nitems; i++) {
+      for (k = 0; k < shape; k++) {
+        if (!bitmap_identical(xb->next + i * shape + k,
+                              yb->next + i * shape + k, t->Record.types[k], 1,
+                              ctx)) {
+          return 0;
+        }
+      }
+    }
+
+    return 1;
+  }
+
+  case Ref: {
+
+    for (i = 0; i < nitems; i++) {
+      if (!bitmap_identical(xb->next + i, yb->next + i, t->Ref.type, 1, ctx)) {
+        return 0;
+      }
+    }
+
+    return 1;
+  }
+
+  case Constr: {
+
+    for (i = 0; i < nitems; i++) {
+      if (!bitmap_identical(xb->next + i, yb->next + i, t->Constr.type, 1,
+                            ctx)) {
+        return 0;
+      }
+    }
+
+    return 1;
+  }
+
+  case Nominal: {
+
+    for (i = 0; i < nitems; i++) {
+      if (!bitmap_identical(xb->next + i, yb->next + i, t->Nominal.type, 1,
+                            ctx)) {
+        return 0;
+      }
+    }
+
+    return 1;
+  }
+
+  default:
+    return 1;
+  }
+}
+
 int
 xnd_bitmap_init(xnd_bitmap_t *b, const ndt_t *t, ndt_context_t *ctx)
 {
@@ -348,4 +457,10 @@ xnd_is_na(const xnd_t *x)
     }
 
     return !_xnd_is_valid(x);
+}
+
+int
+xnd_bitmap_identical(const xnd_bitmap_t *xb, const xnd_bitmap_t *yb,
+                     const ndt_t *t, ndt_context_t *ctx) {
+  return bitmap_identical(xb, yb, t, 1, ctx);
 }

--- a/libxnd/identical.c
+++ b/libxnd/identical.c
@@ -1,0 +1,76 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2017-2018, plures
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ndtypes.h"
+#include "xnd.h"
+#include <assert.h>
+//#include <inttypes.h>
+//#include <stdint.h>
+//#include <stdlib.h>
+#include <string.h>
+
+/*****************************************************************************/
+/*                      Structural identity                                  */
+/*****************************************************************************/
+
+int xnd_identical(const xnd_t *x, const xnd_t *y, ndt_context_t *ctx) {
+
+  const ndt_t *const t = x->type;
+  const ndt_t *const u = y->type;
+  int64_t sz;
+
+  assert(ndt_is_concrete(t) && ndt_is_concrete(u));
+
+  if (x == y) {
+    return 1;
+  }
+
+  if (!ndt_equal(t, u)) {
+    return 0;
+  }
+
+  if (!xnd_bitmap_identical(&x->bitmap, &y->bitmap, t, ctx)) {
+    return 0;
+  }
+
+  sz = XND_BYTES_SIZE(x->ptr);
+  if (sz != XND_BYTES_SIZE(y->ptr)) {
+    return 0;
+  }
+
+  if (memcmp(XND_BYTES_DATA(x->ptr), XND_BYTES_DATA(y->ptr), sz)) {
+    return 0;
+  }
+
+  return 1;
+}

--- a/libxnd/xnd.h
+++ b/libxnd/xnd.h
@@ -190,6 +190,7 @@ XND_API xnd_t *xnd_split(const xnd_t *x, int64_t *n, int max_outer, ndt_context_
 
 XND_API int xnd_equal(const xnd_t *x, const xnd_t *y, ndt_context_t *ctx);
 XND_API int xnd_strict_equal(const xnd_t *x, const xnd_t *y, ndt_context_t *ctx);
+XND_API int xnd_identical(const xnd_t *x, const xnd_t *y, ndt_context_t *ctx);
 
 XND_API int xnd_copy(xnd_t *y, const xnd_t *x, uint32_t flags, ndt_context_t *ctx);
 
@@ -213,6 +214,8 @@ XND_API void xnd_set_valid(xnd_t *x);
 XND_API void xnd_set_na(xnd_t *x);
 XND_API int xnd_is_valid(const xnd_t *x);
 XND_API int xnd_is_na(const xnd_t *x);
+XND_API int xnd_bitmap_identical(const xnd_bitmap_t *xb, const xnd_bitmap_t *yb,
+                                 const ndt_t *t, ndt_context_t *ctx);
 
 
 /*****************************************************************************/


### PR DESCRIPTION
This PR introduces `identity` function for structural equality tests.

- [x] C function `xnd_identity`
- [x] C function `xnd_bitmap_identity`
- [ ] Python function `identity(x, y)`
- [ ] extend to `identity(x, y, elementwise=True)`
- [ ] Add unittests for `identity`
- [ ] Update documentation